### PR TITLE
Explicit JSON Schema factory 

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -5,7 +5,7 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"
             :distribution :repo
             :comments "same as Clojure"}
-  :dependencies [[cheshire "5.6.1"]
+  :dependencies [[cheshire "5.6.3"]
                  [com.github.fge/json-schema-validator "2.2.6"]]
   :profiles {:dev {:dependencies [[org.clojure/clojure "1.8.0"]
                                   [org.codehaus.jsr166-mirror/jsr166y "1.7.0"]

--- a/src/scjsv/core.clj
+++ b/src/scjsv/core.clj
@@ -19,9 +19,8 @@
 
 (defn- validate
   "Validates (f data) against a given JSON Schema."
-  [json-schema f data]
-  (let [json-string (f data)
-        json-data (JsonLoader/fromString json-string)
+  [json-schema data]
+  (let [json-data (JsonLoader/fromString data)
         report (.validate ^JsonSchema json-schema ^JsonNode json-data)
         lp (doto (ListProcessingReport.) (.mergeWith report))
         errors (iterator-seq (.iterator lp))
@@ -39,7 +38,7 @@
   ([schema]
    (json-validator schema (JsonSchemaFactory/byDefault)))
   ([schema json-schema-factory]
-   (partial validate (->json-schema schema json-schema-factory) identity)))
+   (partial validate (->json-schema schema json-schema-factory))))
 
 (defn validator
   "Returns a JSON string validator (a single arity fn).
@@ -47,4 +46,5 @@
   ([schema]
    (validator schema (JsonSchemaFactory/byDefault)))
   ([schema json-schema-factory]
-   (partial validate (->json-schema schema json-schema-factory) c/generate-string)))
+   (comp (partial validate (->json-schema schema json-schema-factory))
+         c/generate-string)))

--- a/src/scjsv/core.clj
+++ b/src/scjsv/core.clj
@@ -33,7 +33,7 @@
 ;;
 
 (defn json-validator
-  "Returns a Clojure data structure validator (a single arity fn).
+  "Returns a JSON string validator (a single arity fn).
   Schema can be given either as a JSON String or a Clojure Map."
   ([schema]
    (json-validator schema (JsonSchemaFactory/byDefault)))
@@ -41,7 +41,7 @@
    (partial validate (->json-schema schema json-schema-factory))))
 
 (defn validator
-  "Returns a JSON string validator (a single arity fn).
+  "Returns a Clojure data structure validator (a single arity fn).
   Schema can be given either as a JSON String or a Clojure Map."
   ([schema]
    (validator schema (JsonSchemaFactory/byDefault)))

--- a/test/scjsv/core_test.clj
+++ b/test/scjsv/core_test.clj
@@ -1,7 +1,8 @@
 (ns scjsv.core-test
   (:require [midje.sweet :refer :all]
             [scjsv.core :as v]
-            [clojure.java.io :as io]))
+            [clojure.java.io :as io])
+  (:import [com.github.fge.jsonschema.main JsonSchemaFactory]))
 
 (fact "Validating JSON string against JSON Schema (as string)"
   (let [schema (slurp (io/resource "scjsv/schema.json"))
@@ -22,6 +23,7 @@
                                                      :state {:type "string"}}
                                         :required ["street_address", "city", "state"]}}}
         validate (v/validator schema)
+        validate-with-explicit-factory (v/validator schema (JsonSchemaFactory/byDefault))
         valid {:shipping_address {:street_address "1600 Pennsylvania Avenue NW"
                                   :city "Washington"
                                   :state "DC"}
@@ -32,6 +34,9 @@
 
     (validate valid) => nil
     (validate invalid) =not=> nil
+
+    (validate-with-explicit-factory valid) => nil
+    (validate-with-explicit-factory invalid) =not=> nil
 
     (fact "validation errors are lovey clojure maps"
       (validate invalid)


### PR DESCRIPTION
This gives callers the option of specifying their own `JsonSchemaFactory` as per #1. I added some other cleanups:
- updated cheshire dependency
- the docstrings for json-validator and validator appeared to be backwards, so I switched them
- removed the `f` parameter to `validate`; now done by the caller (so no more weird `identity` param).

This doesn't impact any public APIs; it only extends them.

Closes #1.
