### PR TITLE
Make it possible to enable inline dereferencing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,6 @@
 ## Unreleased
 
-- Default to [inline dereferencing][inline-deref]. According to the JSON Schema Core specification draft v4, this may break some schemas:
-
-  > Inline dereferencing can produce canonical URIs which differ from the canonical URI of the root schema. Schema authors SHOULD ensure that implementations using canonical dereferencing obtain the same content as implementations using inline dereferencing.
-
-  To use canonical dereferencing (the old behavior), pass a suitable `JsonSchemaFactory` to `validator`/`json-validator`.
+- Make the validator configurable via an options map. You can use it to enable [inline dereferencing][inline-deref] by passing `{:dereferencing :inline}` as the second parameter to `validator`/`json-validator`.
 
 [inline-deref]: (http://json-schema.org/latest/json-schema-core.html#anchor30).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## Unreleased
+
+- Default to [inline dereferencing][inline-deref]. According to the JSON Schema Core specification draft v4, this may break some schemas:
+
+  > Inline dereferencing can produce canonical URIs which differ from the canonical URI of the root schema. Schema authors SHOULD ensure that implementations using canonical dereferencing obtain the same content as implementations using inline dereferencing.
+
+  To use canonical dereferencing (the old behavior), pass a suitable `JsonSchemaFactory` to `validator`/`json-validator`.
+
+[inline-deref]: (http://json-schema.org/latest/json-schema-core.html#anchor30).
+
 ## 0.3.0 (7.8.2016)
 
 - `validator` and `json-validator` now take a `JsonSchemaFactory` as an optional argument. This allows e.g. pre-loading schema definitions.

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject metosin/scjsv "0.3.0"
+(defproject metosin/scjsv "0.4.0-SNAPSHOT"
   :description "Simple JSON-Schema validator for Clojure"
   :url "https://github.com/metosin/scjsv"
   :license {:name "Eclipse Public License"

--- a/test/scjsv/core_test.clj
+++ b/test/scjsv/core_test.clj
@@ -38,7 +38,7 @@
     (validate-with-explicit-factory valid) => nil
     (validate-with-explicit-factory invalid) =not=> nil
 
-    (fact "validation errors are lovey clojure maps"
+    (fact "validation errors are lovely clojure maps"
       (validate invalid)
       => [{:domain "validation"
            :instance {:pointer "/shipping_address"}
@@ -52,6 +52,8 @@
 
 (fact "Validating a schema that refers to itself"
   (let [schema (slurp (io/resource "scjsv/with_id.json"))
-        validate (v/validator schema)
+        default-validate (v/validator schema)
+        inline-validate (v/validator schema {:dereferencing :inline})
         valid {:foo "foo"}]
-    (validate valid) => nil))
+    (default-validate valid) =not=> nil
+    (inline-validate valid) => nil))

--- a/test/scjsv/core_test.clj
+++ b/test/scjsv/core_test.clj
@@ -49,3 +49,9 @@
            :required ["city" "state" "street_address"]
            :schema {:loadingURI "#"
                     :pointer "/definitions/address"}}])))
+
+(fact "Validating a schema that refers to itself"
+  (let [schema (slurp (io/resource "scjsv/with_id.json"))
+        validate (v/validator schema)
+        valid {:foo "foo"}]
+    (validate valid) => nil))

--- a/test/scjsv/with_id.json
+++ b/test/scjsv/with_id.json
@@ -1,0 +1,14 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "id": "resource:/does/not/exist",
+    "properties": {
+        "foo": {
+            "$ref": "#/definitions/foo"
+        }
+    },
+    "definitions": {
+        "foo": {
+            "enum": ["foo"]
+        }
+    }
+}


### PR DESCRIPTION
This avoids downloading a schema from the Internet if it refers to itself. E.g. ring-swagger downloads the Swagger schema from the Internet even though it's bundled into ring-swagger.

See http://json-schema.org/latest/json-schema-core.html#anchor30.
