### PR TITLE
update Java's `json-schema-validator` repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # scjsv [![Build Status](https://travis-ci.org/metosin/scjsv.svg?branch=master)](https://travis-ci.org/metosin/scjsv) [![Dependencies Status](http://jarkeeper.com/metosin/scjsv/status.png)](http://jarkeeper.com/metosin/scjsv)
 
-Simple Clojure JSON-Schema Validator - on top of [com.github.fge/json-schema-validator](https://github.com/fge/json-schema-validator).
+Simple Clojure JSON-Schema Validator - on top of [daveclayton/json-schema-validator](https://github.com/daveclayton/json-schema-validator).
 
 ## Latest version
 


### PR DESCRIPTION
The GitHub owner of the Java client json-schema-validator has moved from
fge to daveclayton. In spite of GitHub's redirect update reference to
new home.