### PR TITLE
Add possibility to pass `deepCheck` property.

### DIFF
--- a/src/scjsv/core.clj
+++ b/src/scjsv/core.clj
@@ -32,14 +32,16 @@
 
 (defn- validate
   "Validates (f data) against a given JSON Schema."
-  [json-schema data]
-  (let [json-data (JsonLoader/fromString data)
-        report (.validate ^JsonSchema json-schema ^JsonNode json-data)
-        lp (doto (ListProcessingReport.) (.mergeWith report))
-        errors (iterator-seq (.iterator lp))
-        ->clj #(-> (.asJson ^ProcessingMessage %) str (c/parse-string true))]
-    (if (seq errors)
-      (map ->clj errors))))
+  ([json-schema data]
+   (validate json-schema data false))
+  ([json-schema data deep-check]
+   (let [json-data (JsonLoader/fromString data)
+         report (.validate ^JsonSchema json-schema ^JsonNode json-data deep-check)
+         lp (doto (ListProcessingReport.) (.mergeWith report))
+         errors (iterator-seq (.iterator lp))
+         ->clj #(-> (.asJson ^ProcessingMessage %) str (c/parse-string true))]
+     (if (seq errors)
+       (map ->clj errors)))))
 
 (defn- ->factory
   "Converts value to a JsonSchemaFactory if it isn't one."

--- a/test/scjsv/core_test.clj
+++ b/test/scjsv/core_test.clj
@@ -10,7 +10,17 @@
         valid (slurp (io/resource "scjsv/valid.json"))
         invalid (slurp (io/resource "scjsv/invalid.json"))]
     (validate valid) => nil
-    (validate invalid) =not=> nil))
+    (validate invalid) =not=> nil
+    (count (validate invalid true)) => 1))
+
+(fact "Validating JSON with deep-check"
+  (let [schema (slurp (io/resource "scjsv/schema_deep.json"))
+        validate (v/json-validator schema)
+        valid (slurp (io/resource "scjsv/valid.json"))
+        invalid (slurp (io/resource "scjsv/deep_invalid.json"))]
+    (validate valid) => nil
+    (validate invalid true) =not=> nil
+    (count (validate invalid true)) => 2))
 
 (fact "Validating Clojure data against JSON Schema (as Clojure)"
   (let [schema {:$schema "http://json-schema.org/draft-04/schema#"

--- a/test/scjsv/deep_invalid.json
+++ b/test/scjsv/deep_invalid.json
@@ -1,0 +1,12 @@
+{
+  "extra_property": "test",
+  "shipping_address": {
+    "street_address": "1600 Pennsylvania Avenue NW",
+    "state": "DC"
+  },
+  "billing_address": {
+    "street_address": "1st Street SE",
+    "city": "Washington",
+    "state": "DC"
+  }
+}

--- a/test/scjsv/schema_deep.json
+++ b/test/scjsv/schema_deep.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "definitions": {
+    "address": {
+      "type": "object",
+      "properties": {
+        "street_address": {"type": "string"},
+        "city": {"type": "string"},
+        "state": {"type": "string"}
+      },
+      "required": [
+        "street_address",
+        "city",
+        "state"
+      ]
+    }
+  },
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "billing_address": {"$ref": "#/definitions/address"},
+    "shipping_address": {"$ref": "#/definitions/address"}
+  }
+}


### PR DESCRIPTION
This allows to check nested elements even if parents are
invalid, so basically you can gather all the errors at once.