### PR TITLE
Use clojure.test instead of midje

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 language: clojure
 lein: 2.7.1
-script: lein with-profile $PROFILE do clean, midje, check
+script: lein with-profile $PROFILE do clean, test, check
 jdk:
   - openjdk6
   - openjdk7

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ Please file bug reports and feature requests to https://github.com/metosin/scjsv
 * Create a topic branch from where you want to base your work (usually the master branch)
 * Check the formatting rules from existing code (no trailing whitepace, mostly default indentation)
 * Ensure any new code is well-tested, and if possible, any issue fixed is covered by one or more new tests
-* Verify that all tests pass using ```lein midje```
+* Verify that all tests pass using ```lein test```
 * Push your code to your fork of the repository
 * Make a Pull Request
 

--- a/project.clj
+++ b/project.clj
@@ -8,14 +8,11 @@
   :dependencies [[cheshire "5.8.0"]
                  [com.github.java-json-tools/json-schema-validator "2.2.8"]]
   :profiles {:dev {:dependencies [[org.clojure/clojure "1.9.0"]
-                                  [org.codehaus.jsr166-mirror/jsr166y "1.7.0"]
-                                  [midje "1.9.1"]]
+                                  [org.codehaus.jsr166-mirror/jsr166y "1.7.0"] ]
                    :plugins [[lein-clojars "0.9.1"]
                              [lein-ring "0.9.7"]
-                             [lein-midje "3.2"]
                              [funcool/codeina "0.5.0" :exclude [org.clojure/clojure]]]}
              :1.7 {:dependencies [[org.clojure/clojure "1.7.0"]]}}
-  :aliases {"test-ancient" ["midje"]}
   :deploy-repositories [["releases" :clojars]]
   :codeina {:sources ["src"]
             :target "gh-pages/doc"


### PR DESCRIPTION
Midje depends on Specter which is broken with Java 7. I'm too lazy to work around that or to deprecate Java 7, so I'm just going to replace Midje with clojure.test.