### PR TITLE
Add the ability to validate data coming from a Reader

### DIFF
--- a/src/scjsv/core.clj
+++ b/src/scjsv/core.clj
@@ -1,12 +1,34 @@
 (ns scjsv.core
-  (:require [cheshire.core :as c])
-  (:import [com.fasterxml.jackson.databind JsonNode]
-           [com.github.fge.jackson JsonLoader]
+  (:require [cheshire.core :as c]
+            [cheshire.factory :as cheshire-factory])
+  (:import [com.fasterxml.jackson.databind JsonNode ObjectMapper]
+           [com.github.fge.jackson JsonNodeReader]
            [com.github.fge.jsonschema.main JsonSchemaFactory]
            [com.github.fge.jsonschema.core.load Dereferencing]
            [com.github.fge.jsonschema.core.load.configuration LoadingConfiguration]
            [com.github.fge.jsonschema.core.report ListProcessingReport ProcessingMessage]
-           [com.github.fge.jsonschema.main JsonSchema]))
+           [com.github.fge.jsonschema.main JsonSchema]
+           [java.io Reader]))
+
+(defn- build-reader
+  "Build a node reader based on the defaults of the cheshire json-factory"
+  []
+  (let [mapper (ObjectMapper. cheshire-factory/json-factory)]
+    (JsonNodeReader. mapper)))
+
+(def ^JsonNodeReader reader (build-reader))
+
+
+(defn- ^JsonNode reader->json-node
+  "Creates a JsonNode from a Reader"
+  [^Reader data-reader]
+  (.fromReader reader data-reader))
+
+(defn- ^JsonNode string->json-node
+  "Creates a JsonNode from a String"
+  [^String data]
+  (reader->json-node (java.io.StringReader. data)))
+
 
 (defn- build-factory
   "Creates a JsonSchemaFactory based on the options map."
@@ -27,14 +49,13 @@
   (let [schema-string (if (string? schema)
                         schema
                         (c/generate-string schema))
-        schema-object (JsonLoader/fromString schema-string)]
+        schema-object (string->json-node schema-string)]
     (.getJsonSchema factory schema-object)))
 
 (defn- validate
-  "Validates (f data) against a given JSON Schema."
-  [json-schema data]
-  (let [json-data (JsonLoader/fromString data)
-        report (.validate ^JsonSchema json-schema ^JsonNode json-data)
+  "Validates (f json-data) against a given JSON Schema."
+  [^JsonSchema json-schema ^JsonNode json-data]
+  (let [report (.validate json-schema json-data)
         lp (doto (ListProcessingReport.) (.mergeWith report))
         errors (iterator-seq (.iterator lp))
         ->clj #(-> (.asJson ^ProcessingMessage %) str (c/parse-string true))]
@@ -50,9 +71,37 @@
     :else (throw (Exception. (str "Don't know how to convert " (pr-str value)
                                   " into a JsonSchemaFactory.")))))
 
+
 ;;
 ;; Public API
 ;;
+
+(defn- build-validator
+  "Returns a validator (a single arity fn).
+  Schema can be given either as a JSON String or a Clojure Map.
+
+  To configure the validator, you can pass a JsonSchemaFactory instance or a
+  options map as the second parameter. See scjsv.core/validator docstring for
+  the options.
+  `->json-node` is the function which will be applied to datum to transform them into
+  a JsonNode"
+  [schema json-schema-factory ->json-node]
+  (comp (partial validate (->json-schema schema (->factory (or json-schema-factory
+                                                     (build-factory {})))))
+      ->json-node))
+
+(defn json-reader-validator
+  "Returns a JSON string validator (a single arity fn).
+  Schema can be given either as a JSON String or a Clojure Map.
+
+  To configure the validator, you can pass a JsonSchemaFactory instance or a
+  options map as the second parameter. See scjsv.core/validator docstring for
+  the options."
+  ([schema]
+   (json-reader-validator schema (build-factory {})))
+  ([schema json-schema-factory]
+   (build-validator schema json-schema-factory reader->json-node)))
+
 
 (defn json-validator
   "Returns a JSON string validator (a single arity fn).
@@ -64,7 +113,9 @@
   ([schema]
    (json-validator schema (build-factory {})))
   ([schema json-schema-factory]
-   (partial validate (->json-schema schema (->factory json-schema-factory)))))
+   (build-validator schema json-schema-factory string->json-node)))
+
+
 
 (defn validator
   "Returns a Clojure data structure validator (a single arity fn).
@@ -79,5 +130,5 @@
   ([schema]
    (validator schema (build-factory {})))
   ([schema json-schema-factory]
-   (comp (partial validate (->json-schema schema (->factory json-schema-factory)))
-         c/generate-string)))
+   (build-validator schema json-schema-factory
+                    (comp string->json-node c/generate-string))))

--- a/test/scjsv/core_test.clj
+++ b/test/scjsv/core_test.clj
@@ -1,9 +1,11 @@
 (ns scjsv.core-test
   (:require [clojure.java.io :as io]
             [clojure.test :refer [deftest is testing]]
+            [cheshire.core :as cheshire]
             [scjsv.core :as v])
   (:import [com.github.fge.jsonschema.core.exceptions ProcessingException]
            [com.github.fge.jsonschema.main JsonSchemaFactory]))
+
 
 (deftest json-string-validation-test
   (testing "Validating JSON string against JSON Schema (as string)"
@@ -14,17 +16,21 @@
       (is (nil? (validate valid)))
       (is (some? (validate invalid))))))
 
+(def delivery-address-schema
+  {:$schema "http://json-schema.org/draft-04/schema#"
+   :type "object"
+   :properties {:billing_address {:$ref "#/definitions/address"}
+                :shipping_address {:$ref "#/definitions/address"}}
+   :definitions {:address {:type "object"
+                           :properties {:street_address {:type "string"}
+                                        :city {:type "string"}
+                                        :state {:type "string"}}
+                           :required ["street_address", "city", "state"]}}})
+
+
 (deftest clojure-data-validation-test
   (testing "Validating Clojure data against JSON Schema (as Clojure)"
-    (let [schema {:$schema "http://json-schema.org/draft-04/schema#"
-                  :type "object"
-                  :properties {:billing_address {:$ref "#/definitions/address"}
-                               :shipping_address {:$ref "#/definitions/address"}}
-                  :definitions {:address {:type "object"
-                                          :properties {:street_address {:type "string"}
-                                                       :city {:type "string"}
-                                                       :state {:type "string"}}
-                                          :required ["street_address", "city", "state"]}}}
+    (let [schema delivery-address-schema
           validate (v/validator schema)
           validate-with-explicit-factory (v/validator schema (JsonSchemaFactory/byDefault))
           valid {:shipping_address {:street_address "1600 Pennsylvania Avenue NW"
@@ -52,6 +58,41 @@
                  :required ["city" "state" "street_address"]
                  :schema {:loadingURI "#"
                           :pointer "/definitions/address"}}]))))))
+
+
+(deftest json-validation-test
+  (testing "Testing json data validation against JSON Schema (as JSON)"
+    (let [schema delivery-address-schema
+          validate (v/json-validator schema)
+          valid {:shipping_address {:street_address "1600 Pennsylvania Avenue NW"
+                                    :city "Washington"
+                                    :state "DC"}
+                 :billing_address {:street_address "1st Street SE"
+                                   :city "Washington"
+                                   :state "DC"}}
+          invalid (update-in valid [:shipping_address] dissoc :state)]
+      (is (nil? (validate (cheshire/generate-string valid))))
+      (is (some? (validate (cheshire/generate-string invalid)))))))
+
+
+(deftest reader-validation-test
+  (testing "Testing json data validation against JSON Schema (as JSON from a Reader)"
+    (let [schema delivery-address-schema
+          validate (v/json-reader-validator schema)
+          valid {:shipping_address {:street_address "1600 Pennsylvania Avenue NW"
+                                    :city "Washington"
+                                    :state "DC"}
+                 :billing_address {:street_address "1st Street SE"
+                                   :city "Washington"
+                                   :state "DC"}}
+          invalid (update-in valid [:shipping_address] dissoc :state)
+          ->reader (comp io/reader io/input-stream
+                      (fn [s] (.getBytes s))
+                      cheshire/generate-string)]
+
+      (is (nil? (validate (->reader valid))))
+      (is (some? (validate (->reader invalid)))))))
+
 
 (deftest self-referential-schema-test
   (testing "Validating a schema that refers to itself"


### PR DESCRIPTION
Hi,

We use scjsv to validate datum which can sometimes be big (~1Mb).
After running some benchmarks we noticed that the conversions into String or from Clojure maps to Strings to finally be converted to JsonNode is not very efficient.

This PR allow a Reader to be passed to validate the datum.

* Sometimes the data does not need to be loaded as a big clojure map or string, in that case it is faster to pass a Reader to validate the datum.
* This also introduce a change to use the cheshire factory to parse the data and returns a JsonNode.
* Added a few tests for the different validate functions.